### PR TITLE
Fixed files always being saved with .pdf extension

### DIFF
--- a/src/Application/Command/CommentOrder.php
+++ b/src/Application/Command/CommentOrder.php
@@ -17,13 +17,13 @@ final class CommentOrder
     /** @var string */
     private $message;
 
-    /** @var UploadedFile */
+    /** @var UploadedFile|null */
     private $file;
 
     /** @var bool */
     private $notifyCustomer;
 
-    private function __construct(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, UploadedFile $file = null)
+    private function __construct(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, ?UploadedFile $file = null)
     {
         $this->orderNumber = $orderNumber;
         $this->authorEmail = $authorEmail;
@@ -32,7 +32,7 @@ final class CommentOrder
         $this->file = $file;
     }
 
-    public static function create(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, UploadedFile $file = null): self
+    public static function create(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, ?UploadedFile $file = null): self
     {
         return new self($orderNumber, $authorEmail, $message, $notifyCustomer, $file);
     }

--- a/src/Application/Command/CommentOrder.php
+++ b/src/Application/Command/CommentOrder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\OrderCommentsPlugin\Application\Command;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 final class CommentOrder
 {
     /** @var string */
@@ -15,13 +17,13 @@ final class CommentOrder
     /** @var string */
     private $message;
 
-    /** @var \SplFileInfo */
+    /** @var UploadedFile */
     private $file;
 
     /** @var bool */
     private $notifyCustomer;
 
-    private function __construct(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, \SplFileInfo $file = null)
+    private function __construct(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, UploadedFile $file = null)
     {
         $this->orderNumber = $orderNumber;
         $this->authorEmail = $authorEmail;
@@ -30,7 +32,7 @@ final class CommentOrder
         $this->file = $file;
     }
 
-    public static function create(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, \SplFileInfo $file = null): self
+    public static function create(string $orderNumber, string $authorEmail, string $message, bool $notifyCustomer, UploadedFile $file = null): self
     {
         return new self($orderNumber, $authorEmail, $message, $notifyCustomer, $file);
     }
@@ -50,7 +52,7 @@ final class CommentOrder
         return $this->message;
     }
 
-    public function file(): ?\SplFileInfo
+    public function file(): ?UploadedFile
     {
         return $this->file;
     }

--- a/src/Application/CommandHandler/CommentOrderHandler.php
+++ b/src/Application/CommandHandler/CommentOrderHandler.php
@@ -47,8 +47,8 @@ final class CommentOrderHandler
         $file = $command->file();
         if (null !== $file) {
             $extension = $file->guessExtension() ?? 'pdf';
+            $fileName  = Uuid::uuid4()->toString() . '.' . $extension;
 
-            $fileName = Uuid::uuid4()->toString() . '.' . $extension;
             $file->move($this->fileDir, $fileName);
             $comment->attachFile($this->fileDir . '/' . $fileName);
         }

--- a/src/Application/CommandHandler/CommentOrderHandler.php
+++ b/src/Application/CommandHandler/CommentOrderHandler.php
@@ -20,16 +20,21 @@ final class CommentOrderHandler
     /** @var EntityManagerInterface */
     private $entityManager;
 
+    /** @var FilesystemInterface */
+    private $fileSystem;
+
     /** @var string */
     private $fileDir;
 
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         EntityManagerInterface $entityManager,
+        FilesystemInterface $fileSystem,
         string $fileDir
     ) {
         $this->orderRepository = $orderRepository;
         $this->entityManager = $entityManager;
+        $this->fileSystem = $fileSystem;
         $this->fileDir = $fileDir;
     }
 
@@ -47,10 +52,10 @@ final class CommentOrderHandler
         $file = $command->file();
         if (null !== $file) {
             $extension = $file->guessExtension() ?? 'pdf';
-            $fileName  = Uuid::uuid4()->toString() . '.' . $extension;
+            $path  = Uuid::uuid4()->toString() . '.' . $extension;
 
-            $file->move($this->fileDir, $fileName);
-            $comment->attachFile($this->fileDir . '/' . $fileName);
+            $this->fileSystem->write($path, file_get_contents($command->file()->getPathname()));
+            $comment->attachFile($this->fileDir . '/' . $path);
         }
 
         $this->entityManager->persist($comment);

--- a/src/Infrastructure/Resources/config/services.xml
+++ b/src/Infrastructure/Resources/config/services.xml
@@ -7,13 +7,12 @@
     <services>
         <defaults public="true" />
 
-       <service id="sylius_order_comment_plugin.command_handler.comment_order_by_customer" class="Sylius\OrderCommentsPlugin\Application\CommandHandler\CommentOrderHandler">
-           <argument type="service" id="sylius.repository.order" />
-           <argument type="service" id="doctrine.orm.default_entity_manager" />
-           <argument type="service" id="gaufrette.sylius_comments_attachment_filesystem" />
-           <argument type="string">media/comment_attachments</argument>
-           <tag name="command_handler" handles="Sylius\OrderCommentsPlugin\Application\Command\CommentOrder" />
-       </service>
+        <service id="sylius_order_comment_plugin.command_handler.comment_order_by_customer" class="Sylius\OrderCommentsPlugin\Application\CommandHandler\CommentOrderHandler">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="string">media/comment_attachments</argument>
+            <tag name="command_handler" handles="Sylius\OrderCommentsPlugin\Application\Command\CommentOrder" />
+        </service>
 
         <service id="sylius_admin_order_comment_plugin.block_event_listener" class="Sylius\Bundle\UiBundle\Block\BlockEventListener">
             <argument>@SyliusOrderCommentsPlugin/injected/admin_order_comments.html.twig</argument>

--- a/src/Infrastructure/Resources/config/services.xml
+++ b/src/Infrastructure/Resources/config/services.xml
@@ -10,6 +10,7 @@
         <service id="sylius_order_comment_plugin.command_handler.comment_order_by_customer" class="Sylius\OrderCommentsPlugin\Application\CommandHandler\CommentOrderHandler">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="gaufrette.sylius_comments_attachment_filesystem" />
             <argument type="string">media/comment_attachments</argument>
             <tag name="command_handler" handles="Sylius\OrderCommentsPlugin\Application\Command\CommentOrder" />
         </service>

--- a/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
+++ b/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
@@ -63,7 +63,7 @@ final class CustomerOrderCommentsContext implements Context
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
         $filePath = __DIR__ . '/../../../Comments/Infrastructure/Form/Type/' . $fileName;
-        $file = new UploadedFile($filePath, $fileName);
+        $file = new UploadedFile($filePath, $fileName, null, null, true);
 
         $this->commandBus->handle(CommentOrder::create($order->getNumber(), $user->getEmail(), $message, true, $file));
     }

--- a/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
+++ b/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
@@ -62,8 +62,14 @@ final class CustomerOrderCommentsContext implements Context
     {
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
-        $filePath = __DIR__ . '/../../../Comments/Infrastructure/Form/Type/' . $fileName;
-        $file = new UploadedFile($filePath, $fileName, null, null, true);
+        $originalFilePath = __DIR__ . '/../../../Comments/Infrastructure/Form/Type/' . $fileName;
+
+        // Copy the file, because the handler will move it.
+        $filePath = $originalFilePath.'.bkp';
+        copy($originalFilePath, $filePath);
+
+        // Symfony 3.4 style
+        $file = new UploadedFile($filePath, $filePath, null, null, null, true);
 
         $this->commandBus->handle(CommentOrder::create($order->getNumber(), $user->getEmail(), $message, true, $file));
     }

--- a/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
+++ b/tests/Behat/Context/Application/CustomerOrderCommentsContext.php
@@ -14,6 +14,7 @@ use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\OrderCommentsPlugin\Application\Command\CommentOrder;
 use Sylius\OrderCommentsPlugin\Domain\Model\Comment;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Webmozart\Assert\Assert;
 
 final class CustomerOrderCommentsContext implements Context
@@ -62,7 +63,7 @@ final class CustomerOrderCommentsContext implements Context
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
         $filePath = __DIR__ . '/../../../Comments/Infrastructure/Form/Type/' . $fileName;
-        $file = new \SplFileInfo($filePath);
+        $file = new UploadedFile($filePath, $fileName);
 
         $this->commandBus->handle(CommentOrder::create($order->getNumber(), $user->getEmail(), $message, true, $file));
     }

--- a/tests/Comments/Application/Command/CommentOrderTest.php
+++ b/tests/Comments/Application/Command/CommentOrderTest.php
@@ -28,10 +28,10 @@ final class CommentOrderTest extends TestCase
      */
     public function it_has_option_file_path_and_file_type(): void
     {
-        $fileName = 'text.txt';
+        $filePath = __DIR__.'/../../Infrastructure/Form/Type/text.txt';
 
         // Symfony 3.4 style
-        $file = new UploadedFile($fileName, $fileName, null, null, null, true);
+        $file = new UploadedFile($filePath, $filePath, null, null, null, true);
         $command = CommentOrder::create('#00002', 'test@test.com', 'Hello', true, $file);
 
         $this->assertEquals($file, $command->file());

--- a/tests/Comments/Application/Command/CommentOrderTest.php
+++ b/tests/Comments/Application/Command/CommentOrderTest.php
@@ -28,7 +28,9 @@ final class CommentOrderTest extends TestCase
      */
     public function it_has_option_file_path_and_file_type(): void
     {
-        $file = new UploadedFile('text.txt', 'not_text.txt');
+        $fileName = 'text.txt';
+
+        $file = new UploadedFile($fileName, $fileName, null, null, true);
         $command = CommentOrder::create('#00002', 'test@test.com', 'Hello', true, $file);
 
         $this->assertEquals($file, $command->file());

--- a/tests/Comments/Application/Command/CommentOrderTest.php
+++ b/tests/Comments/Application/Command/CommentOrderTest.php
@@ -6,6 +6,7 @@ namespace Tests\Sylius\OrderCommentsPlugin\Comments\Application\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sylius\OrderCommentsPlugin\Application\Command\CommentOrder;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 final class CommentOrderTest extends TestCase
 {
@@ -27,7 +28,7 @@ final class CommentOrderTest extends TestCase
      */
     public function it_has_option_file_path_and_file_type(): void
     {
-        $file = new \SplFileInfo('text.txt');
+        $file = new UploadedFile('text.txt', 'not_text.txt');
         $command = CommentOrder::create('#00002', 'test@test.com', 'Hello', true, $file);
 
         $this->assertEquals($file, $command->file());

--- a/tests/Comments/Application/Command/CommentOrderTest.php
+++ b/tests/Comments/Application/Command/CommentOrderTest.php
@@ -30,7 +30,8 @@ final class CommentOrderTest extends TestCase
     {
         $fileName = 'text.txt';
 
-        $file = new UploadedFile($fileName, $fileName, null, null, true);
+        // Symfony 3.4 style
+        $file = new UploadedFile($fileName, $fileName, null, null, null, true);
         $command = CommentOrder::create('#00002', 'test@test.com', 'Hello', true, $file);
 
         $this->assertEquals($file, $command->file());


### PR DESCRIPTION
**Before:**
`$command->file()->getExtension()` always returned an empty string, therefore defaulting the file extension to `.pdf`.

**After:**
File uploads are handled in a more Symfony way: https://symfony.com/doc/current/controller/upload_file.html