### PR TITLE
Admin-comments now sent attached files to customers

### DIFF
--- a/src/Application/CommandHandler/CommentOrderHandler.php
+++ b/src/Application/CommandHandler/CommentOrderHandler.php
@@ -57,7 +57,7 @@ final class CommentOrderHandler
             $comment->attachFile($this->fileDir . '/' . $path);
         }
 
-        $comment->sendNewCommentEmail();
+        $comment->orderCommented();
 
         $this->entityManager->persist($comment);
     }

--- a/src/Application/CommandHandler/CommentOrderHandler.php
+++ b/src/Application/CommandHandler/CommentOrderHandler.php
@@ -57,6 +57,8 @@ final class CommentOrderHandler
             $comment->attachFile($this->fileDir . '/' . $path);
         }
 
+        $comment->sendNewCommentEmail();
+
         $this->entityManager->persist($comment);
     }
 }

--- a/src/Application/Process/SendUnreadCommentEmailNotification.php
+++ b/src/Application/Process/SendUnreadCommentEmailNotification.php
@@ -48,7 +48,7 @@ final class SendUnreadCommentEmailNotification
         string $authorEmail,
         ?AttachedFile $attachedFile
     ): void {
-        $attachedFile = ($attachedFile === null) ? [] : [$attachedFile->path()];
+        $attachments = ($attachedFile === null) ? [] : [$attachedFile->path()];
 
         $this->emailSender->send(
             'unread_comment',
@@ -58,7 +58,7 @@ final class SendUnreadCommentEmailNotification
                 'message' => $message,
                 'authorEmail' => $authorEmail,
             ],
-            $attachedFile
+            $attachments
         );
     }
 }

--- a/src/Application/Process/SendUnreadCommentEmailNotification.php
+++ b/src/Application/Process/SendUnreadCommentEmailNotification.php
@@ -8,6 +8,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\OrderCommentsPlugin\Domain\Event\OrderCommented;
+use Sylius\OrderCommentsPlugin\Domain\Model\AttachedFile;
 
 final class SendUnreadCommentEmailNotification
 {
@@ -35,7 +36,8 @@ final class SendUnreadCommentEmailNotification
             array_diff(array_filter($recipients), [$event->authorEmail()]),
             $order,
             $event->message(),
-            (string) $event->authorEmail()
+            (string) $event->authorEmail(),
+            $event->attachedFile()
         );
     }
 
@@ -43,8 +45,11 @@ final class SendUnreadCommentEmailNotification
         array $recipients,
         OrderInterface $order,
         string $message,
-        string $authorEmail
+        string $authorEmail,
+        ?AttachedFile $attachedFile
     ): void {
+        $attachedFile = ($attachedFile === null) ? [] : [$attachedFile->path()];
+
         $this->emailSender->send(
             'unread_comment',
             $recipients,
@@ -52,7 +57,8 @@ final class SendUnreadCommentEmailNotification
                 'order' => $order,
                 'message' => $message,
                 'authorEmail' => $authorEmail,
-            ]
+            ],
+            $attachedFile
         );
     }
 }

--- a/src/Domain/Event/OrderCommented.php
+++ b/src/Domain/Event/OrderCommented.php
@@ -6,6 +6,7 @@ namespace Sylius\OrderCommentsPlugin\Domain\Event;
 
 use Ramsey\Uuid\UuidInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\OrderCommentsPlugin\Domain\Model\AttachedFile;
 use Sylius\OrderCommentsPlugin\Domain\Model\Email;
 
 final class OrderCommented
@@ -28,13 +29,17 @@ final class OrderCommented
     /** @var bool */
     private $notifyCustomer;
 
+    /** @var AttachedFile */
+    private $attachedFile;
+
     private function __construct(
         UuidInterface $orderCommentId,
         OrderInterface $order,
         Email $authorEmail,
         string $message,
         bool $notifyCustomer,
-        \DateTimeInterface $createdAt
+        \DateTimeInterface $createdAt,
+        AttachedFile $attachedFile = null
     ) {
         $this->orderCommentId = $orderCommentId;
         $this->order = $order;
@@ -42,6 +47,7 @@ final class OrderCommented
         $this->message = $message;
         $this->notifyCustomer = $notifyCustomer;
         $this->createdAt = $createdAt;
+        $this->attachedFile = $attachedFile;
     }
 
     public static function occur(
@@ -50,9 +56,10 @@ final class OrderCommented
         Email $authorEmail,
         string $message,
         bool $notifyCustomer,
-        \DateTimeInterface $createdAt
+        \DateTimeInterface $createdAt,
+        AttachedFile $attachedFile = null
     ): self {
-        return new self($orderCommentId, $order, $authorEmail, $message, $notifyCustomer, $createdAt);
+        return new self($orderCommentId, $order, $authorEmail, $message, $notifyCustomer, $createdAt, $attachedFile);
     }
 
     public function orderCommentId(): UuidInterface
@@ -83,5 +90,10 @@ final class OrderCommented
     public function createdAt(): \DateTimeInterface
     {
         return $this->createdAt;
+    }
+
+    public function attachedFile(): ?AttachedFile
+    {
+        return $this->attachedFile;
     }
 }

--- a/src/Domain/Model/Comment.php
+++ b/src/Domain/Model/Comment.php
@@ -61,7 +61,7 @@ final class Comment implements ResourceInterface, ContainsRecordedMessages
         );
     }
 
-    public function sendNewCommentEmail(): void
+    public function orderCommented(): void
     {
         $this->record(
             OrderCommented::occur(

--- a/src/Domain/Model/Comment.php
+++ b/src/Domain/Model/Comment.php
@@ -50,17 +50,6 @@ final class Comment implements ResourceInterface, ContainsRecordedMessages
         $this->message = $message;
         $this->notifyCustomer = $notifyCustomer;
         $this->createdAt = new \DateTimeImmutable();
-
-        $this->record(
-            OrderCommented::occur(
-                $this->id,
-                $this->order,
-                $this->authorEmail,
-                $this->message,
-                $this->notifyCustomer,
-                $this->createdAt
-            )
-        );
     }
 
     public function attachFile(string $path)
@@ -69,6 +58,21 @@ final class Comment implements ResourceInterface, ContainsRecordedMessages
 
         $this->record(
             FileAttached::occur($this->attachedFile->path())
+        );
+    }
+
+    public function sendNewCommentEmail(): void
+    {
+        $this->record(
+            OrderCommented::occur(
+                $this->getId(),
+                $this->order(),
+                $this->authorEmail(),
+                $this->message(),
+                $this->notifyCustomer(),
+                $this->createdAt(),
+                $this->attachedFile()
+            )
         );
     }
 

--- a/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
+++ b/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
@@ -31,7 +31,10 @@ final class AdministratorOrderCommentsContext implements Context
     {
         /** @var AdminUserInterface $user */
         $user = $this->sharedStorage->get('administrator');
-        $this->sharedStorage->set('comment', new Comment($order, $user->getEmail(), $message, true));
+        $comment = new Comment($order, $user->getEmail(), $message, true);
+        $comment->sendNewCommentEmail();
+
+        $this->sharedStorage->set('comment', $comment);
     }
 
     /**
@@ -41,7 +44,10 @@ final class AdministratorOrderCommentsContext implements Context
     {
         /** @var AdminUserInterface $user */
         $user = $this->sharedStorage->get('administrator');
-        $this->sharedStorage->set('comment', new Comment($order, $user->getEmail(), $message, false));
+        $comment = new Comment($order, $user->getEmail(), $message, false);
+        $comment->sendNewCommentEmail();
+
+        $this->sharedStorage->set('comment', $comment);
     }
 
     /**

--- a/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
+++ b/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
@@ -32,7 +32,7 @@ final class AdministratorOrderCommentsContext implements Context
         /** @var AdminUserInterface $user */
         $user = $this->sharedStorage->get('administrator');
         $comment = new Comment($order, $user->getEmail(), $message, true);
-        $comment->sendNewCommentEmail();
+        $comment->orderCommented();
 
         $this->sharedStorage->set('comment', $comment);
     }
@@ -45,7 +45,7 @@ final class AdministratorOrderCommentsContext implements Context
         /** @var AdminUserInterface $user */
         $user = $this->sharedStorage->get('administrator');
         $comment = new Comment($order, $user->getEmail(), $message, false);
-        $comment->sendNewCommentEmail();
+        $comment->orderCommented();
 
         $this->sharedStorage->set('comment', $comment);
     }

--- a/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
+++ b/tests/Behat/Context/Domain/AdministratorOrderCommentsContext.php
@@ -29,12 +29,7 @@ final class AdministratorOrderCommentsContext implements Context
      */
     public function iCommentTheOrderWithMessageAndCheckboxEnabled(OrderInterface $order, string $message): void
     {
-        /** @var AdminUserInterface $user */
-        $user = $this->sharedStorage->get('administrator');
-        $comment = new Comment($order, $user->getEmail(), $message, true);
-        $comment->orderCommented();
-
-        $this->sharedStorage->set('comment', $comment);
+        $this->commentOrder($order, $message, true);
     }
 
     /**
@@ -42,12 +37,7 @@ final class AdministratorOrderCommentsContext implements Context
      */
     public function iCommentTheOrderWithMessageAndCheckboxDisabled(OrderInterface $order, string $message): void
     {
-        /** @var AdminUserInterface $user */
-        $user = $this->sharedStorage->get('administrator');
-        $comment = new Comment($order, $user->getEmail(), $message, false);
-        $comment->orderCommented();
-
-        $this->sharedStorage->set('comment', $comment);
+        $this->commentOrder($order, $message, false);
     }
 
     /**
@@ -85,6 +75,22 @@ final class AdministratorOrderCommentsContext implements Context
                 $message, $order->getNumber(), $user->getEmail()
             ));
         }
+    }
+
+    /**
+     * Creates a new comment and sets it into the shared storage.
+     * @param OrderInterface $order
+     * @param string $message
+     * @param bool $notifyCustomer
+     */
+    private function commentOrder(OrderInterface $order, string $message, bool $notifyCustomer): void
+    {
+        /** @var AdminUserInterface $user */
+        $user = $this->sharedStorage->get('administrator');
+        $comment = new Comment($order, $user->getEmail(), $message, $notifyCustomer);
+        $comment->orderCommented();
+
+        $this->sharedStorage->set('comment', $comment);
     }
 
     /**

--- a/tests/Behat/Context/Domain/CustomerOrderCommentsContext.php
+++ b/tests/Behat/Context/Domain/CustomerOrderCommentsContext.php
@@ -32,7 +32,7 @@ final class CustomerOrderCommentsContext implements Context
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
         $comment = new Comment($order, $user->getEmail(), $message, true);
-        $comment->sendNewCommentEmail();
+        $comment->orderCommented();
 
         $this->sharedStorage->set('comment', $comment);
     }
@@ -46,7 +46,7 @@ final class CustomerOrderCommentsContext implements Context
         $user = $this->sharedStorage->get('user');
         $comment = new Comment($order, $user->getEmail(), $message, true);
         $comment->attachFile($fileName);
-        $comment->sendNewCommentEmail();
+        $comment->orderCommented();
 
         $this->sharedStorage->set('comment', $comment);
     }
@@ -60,7 +60,7 @@ final class CustomerOrderCommentsContext implements Context
         $user = $this->sharedStorage->get('user');
         try {
             $comment = new Comment($order, $user->getEmail(), '', true);
-            $comment->sendNewCommentEmail();
+            $comment->orderCommented();
 
             $this->sharedStorage->set('comment', $comment);
         } catch (\DomainException $exception) {
@@ -75,7 +75,7 @@ final class CustomerOrderCommentsContext implements Context
     {
         try {
             $comment = new Comment($order, $email, 'Hello', true);
-            $comment->sendNewCommentEmail();
+            $comment->orderCommented();
 
             $this->sharedStorage->set('comment', $comment);
         } catch (\DomainException $exception) {

--- a/tests/Behat/Context/Domain/CustomerOrderCommentsContext.php
+++ b/tests/Behat/Context/Domain/CustomerOrderCommentsContext.php
@@ -31,7 +31,10 @@ final class CustomerOrderCommentsContext implements Context
     {
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
-        $this->sharedStorage->set('comment', new Comment($order, $user->getEmail(), $message, true));
+        $comment = new Comment($order, $user->getEmail(), $message, true);
+        $comment->sendNewCommentEmail();
+
+        $this->sharedStorage->set('comment', $comment);
     }
 
     /**
@@ -43,6 +46,8 @@ final class CustomerOrderCommentsContext implements Context
         $user = $this->sharedStorage->get('user');
         $comment = new Comment($order, $user->getEmail(), $message, true);
         $comment->attachFile($fileName);
+        $comment->sendNewCommentEmail();
+
         $this->sharedStorage->set('comment', $comment);
     }
 
@@ -54,7 +59,10 @@ final class CustomerOrderCommentsContext implements Context
         /** @var ShopUserInterface $user */
         $user = $this->sharedStorage->get('user');
         try {
-            $this->sharedStorage->set('comment', new Comment($order, $user->getEmail(), '', true));
+            $comment = new Comment($order, $user->getEmail(), '', true);
+            $comment->sendNewCommentEmail();
+
+            $this->sharedStorage->set('comment', $comment);
         } catch (\DomainException $exception) {
             $this->sharedStorage->set('exception', $exception);
         }
@@ -66,7 +74,10 @@ final class CustomerOrderCommentsContext implements Context
     public function aCustomerWithEmailTryToCommentAnOrder(string $email, OrderInterface $order): void
     {
         try {
-            $this->sharedStorage->set('comment', new Comment($order, $email, 'Hello', true));
+            $comment = new Comment($order, $email, 'Hello', true);
+            $comment->sendNewCommentEmail();
+
+            $this->sharedStorage->set('comment', $comment);
         } catch (\DomainException $exception) {
             $this->sharedStorage->set('exception', $exception);
         }

--- a/tests/Comments/Domain/Model/CommentTest.php
+++ b/tests/Comments/Domain/Model/CommentTest.php
@@ -58,7 +58,7 @@ final class CommentTest extends TestCase
         $order = new Order();
 
         $comment = new Comment($order, 'test@test.com', 'Hello', true);
-        $comment->attachFile('test/test', 'pdf');
+        $comment->attachFile('test/test.pdf');
 
         $this->assertNotNull($comment->attachedFile());
     }


### PR DESCRIPTION
A comment with an attachment gets send to the customer without respecting the attachment. It is just natural to send the attachment to the customer with that notification email.

This has been implemented in this pull request by moving the event logic that triggers the email to a separate function on the entity that gets called after any files have been attached and respects the attached file.