### PR TITLE
Fix doctrine mapping for comment entity

### DIFF
--- a/src/Infrastructure/Resources/config/doctrine/model/Comment.orm.xml
+++ b/src/Infrastructure/Resources/config/doctrine/model/Comment.orm.xml
@@ -9,7 +9,7 @@
             <custom-id-generator class="Ramsey\Uuid\Doctrine\UuidGenerator" />
         </id>
 
-        <many-to-one field="order" target-entity="Sylius\Component\Core\Model\Order" >
+        <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" >
             <join-column name="order_id" referenced-column-name="id" nullable="true" />
         </many-to-one>
 


### PR DESCRIPTION
To enable proper override-capabilities of the order-entity I replaced the target entity with an interface to ensure compatibility with the resource-bundle.