### PR TITLE
Sylius 1.3 support

### DIFF
--- a/src/Infrastructure/Resources/config/app/config.yml
+++ b/src/Infrastructure/Resources/config/app/config.yml
@@ -30,7 +30,7 @@ knp_gaufrette:
     adapters:
         sylius_comments_attachment:
             local:
-                directory: "%kernel.root_dir%/../public/media/comment_attachments"
+                directory: "%sylius_core.public_dir%/media/comment_attachments"
                 create: true
     filesystems:
         sylius_comments_attachment:

--- a/src/Infrastructure/Resources/config/app/config.yml
+++ b/src/Infrastructure/Resources/config/app/config.yml
@@ -30,7 +30,7 @@ knp_gaufrette:
     adapters:
         sylius_comments_attachment:
             local:
-                directory: "%kernel.root_dir%/../web/media/comment_attachments"
+                directory: "%kernel.root_dir%/../public/media/comment_attachments"
                 create: true
     filesystems:
         sylius_comments_attachment:


### PR DESCRIPTION
Since version 1.3 Sylius uses the `public` directory instead of `web`.
The path for comment attachments was still pointing in the `web` directory.